### PR TITLE
Latest MKS lets you recycle parts

### DIFF
--- a/GameData/WildBlueIndustries/MCM/Templates/048_Metal.cfg
+++ b/GameData/WildBlueIndustries/MCM/Templates/048_Metal.cfg
@@ -3,10 +3,15 @@ MKSTEMPLATE
   author = Angel-125
   title = Metal Kit
   shortName = Metal
-  description = This configuration stores metal.
+  description = This configuration stores metal and recyclables from scrapped parts.
   mass = 0.75
   TechRequired = specializedConstruction
   templateType = Storage
+
+MODULE
+{
+	name = USI_ModuleRecycleBin
+}
 
 RESOURCE
 {
@@ -15,4 +20,10 @@ RESOURCE
   maxAmount = 2000
 }
 
+RESOURCE
+{
+  name = Recyclables
+  amount = 0
+  maxAmount = 2000
+}
 }


### PR DESCRIPTION
Recycling parts on EVA requires a container in a vicinity of 2 km which can hold Recyclables and has a module USI_ModuleRecycleBin.
Storing them with metals is an obvious choice, because Repair Shop uses both of those resources.